### PR TITLE
Add cd workflow for theme releasing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,18 @@
+name: CD
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  cd:
+    uses: halo-sigs/reusable-workflows/.github/workflows/theme-cd.yaml@v3
+    secrets:
+      halo-pat: ${{ secrets.HALO_PAT }}
+    permissions:
+      contents: write
+    with:
+      app-id: app-KgWqR
+      pnpm-version: 9
+      node-version: 20

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       contents: write
     with:
-      app-id: app-KgWqR
+      app-id: app-JyXQH
       pnpm-version: 9
       node-version: 20

--- a/package.json
+++ b/package.json
@@ -1,45 +1,22 @@
 {
-  "description": "A development starter theme with modern front-end technology stack for Halo",
-  "keywords": [
-    "halo",
-    "halo-theme"
-  ],
-  "homepage": "https://github.com/halo-dev/theme-modern-starter#readme",
-  "bugs": {
-    "url": "https://github.com/halo-dev/theme-modern-starter/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/halo-dev/theme-modern-starter"
-  },
   "license": "GPL-3.0",
-  "author": {
-    "name": "Halo",
-    "email": "hi@halo.run",
-    "url": "https://github.com/halo-dev"
-  },
-  "maintainers": [
-    {
-      "name": "Ryan Wang",
-      "email": "i@ryanc.cc",
-      "url": "https://github.com/ruibaby"
-    }
-  ],
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && pnpm package",
+    "build-only": "vite build",
     "dev": "vite build --watch",
     "lint": "eslint ./src --ext .js,.cjs,.mjs,.ts,.cts,.mts --ignore-path .gitignore",
-    "prettier": "prettier --write './**/*.{ts,json,yaml,yml,html}'",
-    "prepare": "husky"
-  },
-  "dependencies": {
-    "alpinejs": "^3.13.7",
-    "sass": "^1.86.3"
+    "package": "npx @halo-dev/theme-package-cli",
+    "prepare": "husky",
+    "prettier": "prettier --write './**/*.{ts,json,yaml,yml,html}'"
   },
   "lint-staged": {
     "*.{ts,json,yaml,yml,html}": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "alpinejs": "^3.13.7",
+    "sass": "^1.86.3"
   },
   "devDependencies": {
     "@iconify-json/tabler": "^1.1.109",


### PR DESCRIPTION
添加 cd.yaml，用于在创建 Release 之后同步在 Halo 应用市场发布版本。

合并此 PR 之后需要在 https://github.com/Idea-flow/theme-Ideaflow/settings/secrets/actions 创建一个名为 `HALO_PAT` 的 Secret，PAT 需要去 https://www.halo.run/uc/profile?tab=pat 创建，勾选 `应用市场开发者 -> 版本管理` 的权限。

需要注意的是，虽然这个流程会自动打包并发布到应用市场，但在发布版本之前仍然需要手动修改 theme.yaml 的版本号。

详情可见：https://github.com/halo-sigs/reusable-workflows